### PR TITLE
Opt

### DIFF
--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -62,7 +62,7 @@ type Controller struct {
 func NewController(consulAddress string) *Controller {
 	controller := &Controller{
 		consulAddress: consulAddress,
-		pushChannel:   make(chan *ChangeEvent),
+		pushChannel:   make(chan *ChangeEvent, 1),
 	}
 	return controller
 }

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -129,7 +129,7 @@ func (s *Controller) mainLoop(stop <-chan struct{}) {
 					if err != nil {
 						log.Errorf("Failed to synchronize consul services to Istio: %v", err)
 						// Retry if failed
-						s.pushChannel <- &ChangeEvent{}
+						// s.pushChannel <- &ChangeEvent{}
 					}
 					debouncedEvents = 0
 				}

--- a/pkg/serviceregistry/consul/controller.go
+++ b/pkg/serviceregistry/consul/controller.go
@@ -85,7 +85,7 @@ func (c *Controller) initCache() error {
 	if err != nil {
 		return err
 	}
-
+	c.servicesList = nil
 	for serviceName := range consulServices {
 		// get endpoints of a service from consul
 		endpoints, err := c.getCatalogService(serviceName, nil)

--- a/pkg/serviceregistry/consul/monitor.go
+++ b/pkg/serviceregistry/consul/monitor.go
@@ -37,7 +37,10 @@ type consulMonitor struct {
 	ServiceChangeHandlers []ServiceChangeHandler
 }
 
-const blockQueryWaitTime time.Duration = 10 * time.Minute
+const (
+	blockQueryWaitTime          time.Duration = 10 * time.Minute
+	updateServiceRecordWaitTime time.Duration = 10 * time.Second
+)
 
 // NewConsulMonitor watches for changes in Consul services and CatalogServices
 func NewConsulMonitor(client *api.Client) Monitor {
@@ -72,6 +75,7 @@ func (m *consulMonitor) watchConsul(stop <-chan struct{}) {
 			} else if consulWaitIndex != queryMeta.LastIndex {
 				consulWaitIndex = queryMeta.LastIndex
 				m.updateServiceRecord()
+				time.Sleep(updateServiceRecordWaitTime)
 			}
 		}
 	}


### PR DESCRIPTION
修复&优化在使用中发现的一些问题
https://github.com/aeraki-mesh/consul2istio/issues/5
https://github.com/aeraki-mesh/consul2istio/issues/6
https://github.com/aeraki-mesh/consul2istio/issues/7
1、阻塞方式改为非阻塞方式
2、有创建某个se有问题时，会导致其他的创建不成功
3、consul 有变化时，本地由于serviceList中仍然是旧值，导致没有更新本地
4、同步时，由于consul meta或tag中没有指明协议时会走默认的tcp协议，导致不能创建基于http协议的se
5、同步时，在maxIndex不断变化的情况下，不停的从consul sever拉取数据，占用不必要的带宽